### PR TITLE
Fix stretched pokemon images

### DIFF
--- a/src/components/Pokemon/PokemonRow.js
+++ b/src/components/Pokemon/PokemonRow.js
@@ -42,7 +42,6 @@ const styles = {
     justifyContent: 'center',
   },
   pokemonImage: {
-    width: 170,
     height: 170,
   },
 };


### PR DESCRIPTION
The source images are not squared, so the current style is stretching the images. 
Setting only the height makes the images proportional and don't break the page layout.
